### PR TITLE
Add AWS profile support for Bedrock API mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ export OPENAI_API_KEY=...
 export ANTHROPIC_API_KEY=...
 
 # For Bedrock API (e.g., anthropic.claude-3-5-sonnet-20240620-v1:0)
+# Option 1: Use AWS Profile (recommended)
+aws configure --profile my-profile
+# Then use --aws-profile my-profile in the command
+
+# Option 2: Use environment variables
 export AWS_ACCESS_KEY_ID=...
 export AWS_SECRET_ACCESS_KEY=...
 export AWS_SESSION_TOKEN=...
@@ -67,6 +72,19 @@ prompt-hardener improve \
   --max-iterations 3 \
   --test-after \
   --report-dir ~/Downloads
+
+# Example using AWS Bedrock with profile
+prompt-hardener improve \
+  --input-mode chat \
+  --input-format bedrock \
+  --target-prompt-path path/to/prompt.json \
+  --eval-api-mode bedrock \
+  --eval-model anthropic.claude-3-5-sonnet-20240620-v1:0 \
+  --aws-profile my-bedrock-profile \
+  --aws-region us-west-2 \
+  --output-path path/to/hardened.json \
+  --test-after \
+  --report-dir ~/Downloads
 ```
 
 <details>
@@ -84,6 +102,7 @@ prompt-hardener improve \
 | `--judge-api-mode`         | `-ja` | `str`       | ❌ No     | `--eval-api-mode`   | LLM API used for attack insertion and success judgment (defaults to the attack API).                                     |
 | `--judge-model`            | `-jm` | `str`       | ❌ No     | `--eval-model`      | Model used to insert attack payloads and judge injection success (defaults to the attack model).                         |
 | `--aws-region`             | `-ar` | `str`       | ❌ No     | `us-east-1`         | AWS region for Bedrock API mode. Default is `us-east-1`.                                                                 |
+| `--aws-profile`            | `-ap` | `str`       | ❌ No     | `None`              | AWS profile name for Bedrock API mode. If not specified, uses default AWS credential chain.                             |
 | `--user-input-description` | `-ui` | `str`       | ❌ No     | `None`              | Description of user input fields (e.g., `Comments`), used to guide placement and tagging of user data.                   |
 | `--output-path`            | `-o`  | `str`       | ✅ Yes    | -                   | File path to write the final improved prompt as JSON.                                                                    |
 | `--max-iterations`         | `-n`  | `int`       | ❌ No     | `3`                 | Maximum number of improvement iterations.                                                                                |

--- a/src/attack.py
+++ b/src/attack.py
@@ -15,7 +15,12 @@ from utils import extract_json_block
 
 
 def insert_attack_into_prompt(
-    prompt: PromptInput, model: str, attack: str, api_mode: str, aws_region: Optional[str] = None, aws_profile: Optional[str] = None
+    prompt: PromptInput,
+    model: str,
+    attack: str,
+    api_mode: str,
+    aws_region: Optional[str] = None,
+    aws_profile: Optional[str] = None,
 ) -> PromptInput:
     """
     Insert the attack string into the prompt (PromptInput) and return a new PromptInput.
@@ -107,7 +112,9 @@ def insert_attack_into_prompt(
 
         messages = [{"role": "user", "content": injection_prompt.strip()}]
 
-        result = call_llm_api_for_payload_injection(api_mode, model, messages, aws_region, aws_profile)
+        result = call_llm_api_for_payload_injection(
+            api_mode, model, messages, aws_region, aws_profile
+        )
         result = extract_json_block(result)
 
         if prompt.mode == "chat":
@@ -273,7 +280,12 @@ def run_injection_test(
                 system_prompt, random_tag
             )
             final_prompt = insert_attack_into_prompt(
-                normalized_prompt, judge_model, mod_attack, judge_api_mode, aws_region, aws_profile
+                normalized_prompt,
+                judge_model,
+                mod_attack,
+                judge_api_mode,
+                aws_region,
+                aws_profile,
             )
 
             try:

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -9,6 +9,7 @@ def evaluate_prompt(
     target_prompt: PromptInput,
     user_input_description: Optional[str] = None,
     aws_region: Optional[str] = None,
+    aws_profile: Optional[str] = None,
 ) -> Dict:
     system_message = """
     You are a <persona>Prompt Analyst</persona> responsible for evaluating the security of the target prompt.
@@ -86,4 +87,5 @@ def evaluate_prompt(
         criteria=criteria,
         target_prompt=target_prompt,
         aws_region=aws_region,
+        aws_profile=aws_profile,
     )

--- a/src/improve.py
+++ b/src/improve.py
@@ -13,6 +13,7 @@ def improve_prompt(
     user_input_description: Optional[str] = None,
     apply_techniques: Optional[List[str]] = None,
     aws_region: Optional[str] = None,
+    aws_profile: Optional[str] = None,
 ) -> PromptInput:
     if apply_techniques is None:
         apply_techniques = []
@@ -172,6 +173,7 @@ def improve_prompt(
         criteria=criteria,
         target_prompt=target_prompt,
         aws_region=aws_region,
+        aws_profile=aws_profile,
     )
 
     # Post-process result

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -8,8 +8,20 @@ import boto3
 from utils import extract_json_block, to_bedrock_message_format
 from schema import PromptInput
 
-openai_client = OpenAI()
-claude_client = Anthropic()
+openai_client = None
+claude_client = None
+
+def get_openai_client():
+    global openai_client
+    if openai_client is None:
+        openai_client = OpenAI()
+    return openai_client
+
+def get_claude_client():
+    global claude_client
+    if claude_client is None:
+        claude_client = Anthropic()
+    return claude_client
 
 # --- Message builders ---
 
@@ -176,6 +188,7 @@ def call_llm_api_for_eval(
     criteria: str,
     target_prompt: PromptInput,
     aws_region: Optional[str] = None,
+    aws_profile: Optional[str] = None,
 ) -> Union[List[Dict[str, str]], str]:
     try:
         if api_mode == "openai":
@@ -190,7 +203,7 @@ def call_llm_api_for_eval(
             raise ValueError(f"Unsupported api_mode: {api_mode}")
 
         if api_mode == "openai":
-            completion = openai_client.chat.completions.create(
+            completion = get_openai_client().chat.completions.create(
                 model=model_name,
                 messages=messages,
                 temperature=0.2,
@@ -199,7 +212,7 @@ def call_llm_api_for_eval(
             )
             content = completion.choices[0].message.content
         elif api_mode == "claude":
-            completion = claude_client.messages.create(
+            completion = get_claude_client().messages.create(
                 model=model_name,
                 messages=messages,
                 temperature=0.2,
@@ -207,7 +220,8 @@ def call_llm_api_for_eval(
             )
             content = completion.content[0].text
         elif api_mode == "bedrock":
-            bedrock_client = boto3.client("bedrock-runtime", region_name=aws_region)
+            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
+            bedrock_client = session.client("bedrock-runtime", region_name=aws_region)
             json_data = {
                 "anthropic_version": "bedrock-2023-05-31",
                 "messages": messages,
@@ -241,6 +255,7 @@ def call_llm_api_for_improve(
     criteria: str,
     target_prompt: PromptInput,
     aws_region: Optional[str] = None,
+    aws_profile: Optional[str] = None,
 ) -> Dict[str, Any]:
     try:
         if api_mode == "openai":
@@ -255,7 +270,7 @@ def call_llm_api_for_improve(
             raise ValueError(f"Unsupported api_mode: {api_mode}")
 
         if api_mode == "openai":
-            completion = openai_client.chat.completions.create(
+            completion = get_openai_client().chat.completions.create(
                 model=model_name,
                 messages=messages,
                 temperature=0.2,
@@ -265,7 +280,7 @@ def call_llm_api_for_improve(
             content = completion.choices[0].message.content
 
         elif api_mode == "claude":
-            completion = claude_client.messages.create(
+            completion = get_claude_client().messages.create(
                 model=model_name,
                 messages=messages,
                 temperature=0.2,
@@ -274,7 +289,8 @@ def call_llm_api_for_improve(
             content = completion.content[0].text
 
         elif api_mode == "bedrock":
-            bedrock_client = boto3.client("bedrock-runtime", region_name=aws_region)
+            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
+            bedrock_client = session.client("bedrock-runtime", region_name=aws_region)
             json_data = {
                 "anthropic_version": "bedrock-2023-05-31",
                 "messages": messages,
@@ -303,6 +319,7 @@ def call_llm_api_for_payload_injection(
     model: str,
     messages: List[Dict[str, str]],
     aws_region: Optional[str] = None,
+    aws_profile: Optional[str] = None,
 ) -> str:
     try:
         if api_mode == "openai":
@@ -312,7 +329,7 @@ def call_llm_api_for_payload_injection(
                 "temperature": 0.2,
                 "max_tokens": 1024,
             }
-            response = openai_client.chat.completions.create(**kwargs)
+            response = get_openai_client().chat.completions.create(**kwargs)
             return response.choices[0].message.content
 
         elif api_mode == "claude":
@@ -322,11 +339,12 @@ def call_llm_api_for_payload_injection(
                 "temperature": 0.2,
                 "max_tokens": 1024,
             }
-            response = claude_client.messages.create(**kwargs)
+            response = get_claude_client().messages.create(**kwargs)
             return response.content[0].text.strip()
 
         elif api_mode == "bedrock":
-            bedrock_client = boto3.client("bedrock-runtime", region_name=aws_region)
+            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
+            bedrock_client = session.client("bedrock-runtime", region_name=aws_region)
             json_data = {
                 "anthropic_version": "bedrock-2023-05-31",
                 "messages": messages,
@@ -357,6 +375,7 @@ def call_llm_api_for_attack_completion(
     temperature: float = 0.2,
     max_tokens: int = 1024,
     aws_region: Optional[str] = None,
+    aws_profile: Optional[str] = None,
 ) -> str:
     try:
         if api_mode == "openai":
@@ -386,14 +405,15 @@ def call_llm_api_for_attack_completion(
                 "temperature": 0.2,
                 "max_tokens": 1024,
             }
-            response = claude_client.messages.create(**kwargs)
+            response = get_claude_client().messages.create(**kwargs)
             if len(response.content) > 0:
                 return response.content[0].text.strip()
             else:
                 return ""
 
         elif api_mode == "bedrock":
-            bedrock_client = boto3.client("bedrock-runtime", region_name=aws_region)
+            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
+            bedrock_client = session.client("bedrock-runtime", region_name=aws_region)
             kwargs = {
                 "modelId": model,
                 "messages": [{"role": "user", "content": [{"text": prompt}]}],
@@ -427,6 +447,7 @@ def call_llm_api_for_attack_chat(
     temperature: float = 0.2,
     max_tokens: int = 1024,
     aws_region: Optional[str] = None,
+    aws_profile: Optional[str] = None,
 ) -> str:
     try:
         if api_mode == "openai":
@@ -438,7 +459,7 @@ def call_llm_api_for_attack_chat(
             }
             if tools:
                 kwargs["tools"] = tools
-            response = openai_client.chat.completions.create(**kwargs)
+            response = get_openai_client().chat.completions.create(**kwargs)
             if len(response.choices) > 0 and response.choices[0].message:
                 return response.choices[0].message.content
             else:
@@ -454,14 +475,15 @@ def call_llm_api_for_attack_chat(
             }
             if tools:
                 kwargs["tools"] = tools
-            response = claude_client.messages.create(**kwargs)
+            response = get_claude_client().messages.create(**kwargs)
             if len(response.content) > 0:
                 return response.content[0].text.strip()
             else:
                 return ""
 
         elif api_mode == "bedrock":
-            bedrock_client = boto3.client("bedrock-runtime", region_name=aws_region)
+            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
+            bedrock_client = session.client("bedrock-runtime", region_name=aws_region)
             messages = to_bedrock_message_format(messages)
             kwargs = {
                 "modelId": model,
@@ -494,10 +516,11 @@ def call_llm_api_for_judge(
     messages: List[Dict[str, str]],
     temperature: float = 0.0,
     aws_region: Optional[str] = None,
+    aws_profile: Optional[str] = None,
 ) -> str:
     try:
         if api_mode == "openai":
-            response = openai_client.chat.completions.create(
+            response = get_openai_client().chat.completions.create(
                 model=model,
                 messages=messages,
                 temperature=temperature,
@@ -514,7 +537,8 @@ def call_llm_api_for_judge(
             return response.content[0].text.strip()
 
         elif api_mode == "bedrock":
-            bedrock_client = boto3.client("bedrock-runtime", region_name=aws_region)
+            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
+            bedrock_client = session.client("bedrock-runtime", region_name=aws_region)
             json_data = {
                 "anthropic_version": "bedrock-2023-05-31",
                 "messages": messages,

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -11,17 +11,20 @@ from schema import PromptInput
 openai_client = None
 claude_client = None
 
+
 def get_openai_client():
     global openai_client
     if openai_client is None:
         openai_client = OpenAI()
     return openai_client
 
+
 def get_claude_client():
     global claude_client
     if claude_client is None:
         claude_client = Anthropic()
     return claude_client
+
 
 # --- Message builders ---
 
@@ -220,7 +223,11 @@ def call_llm_api_for_eval(
             )
             content = completion.content[0].text
         elif api_mode == "bedrock":
-            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
+            session = (
+                boto3.Session(profile_name=aws_profile)
+                if aws_profile
+                else boto3.Session()
+            )
             bedrock_client = session.client("bedrock-runtime", region_name=aws_region)
             json_data = {
                 "anthropic_version": "bedrock-2023-05-31",
@@ -289,7 +296,11 @@ def call_llm_api_for_improve(
             content = completion.content[0].text
 
         elif api_mode == "bedrock":
-            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
+            session = (
+                boto3.Session(profile_name=aws_profile)
+                if aws_profile
+                else boto3.Session()
+            )
             bedrock_client = session.client("bedrock-runtime", region_name=aws_region)
             json_data = {
                 "anthropic_version": "bedrock-2023-05-31",
@@ -343,7 +354,11 @@ def call_llm_api_for_payload_injection(
             return response.content[0].text.strip()
 
         elif api_mode == "bedrock":
-            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
+            session = (
+                boto3.Session(profile_name=aws_profile)
+                if aws_profile
+                else boto3.Session()
+            )
             bedrock_client = session.client("bedrock-runtime", region_name=aws_region)
             json_data = {
                 "anthropic_version": "bedrock-2023-05-31",
@@ -412,7 +427,11 @@ def call_llm_api_for_attack_completion(
                 return ""
 
         elif api_mode == "bedrock":
-            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
+            session = (
+                boto3.Session(profile_name=aws_profile)
+                if aws_profile
+                else boto3.Session()
+            )
             bedrock_client = session.client("bedrock-runtime", region_name=aws_region)
             kwargs = {
                 "modelId": model,
@@ -482,7 +501,11 @@ def call_llm_api_for_attack_chat(
                 return ""
 
         elif api_mode == "bedrock":
-            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
+            session = (
+                boto3.Session(profile_name=aws_profile)
+                if aws_profile
+                else boto3.Session()
+            )
             bedrock_client = session.client("bedrock-runtime", region_name=aws_region)
             messages = to_bedrock_message_format(messages)
             kwargs = {
@@ -537,7 +560,11 @@ def call_llm_api_for_judge(
             return response.content[0].text.strip()
 
         elif api_mode == "bedrock":
-            session = boto3.Session(profile_name=aws_profile) if aws_profile else boto3.Session()
+            session = (
+                boto3.Session(profile_name=aws_profile)
+                if aws_profile
+                else boto3.Session()
+            )
             bedrock_client = session.client("bedrock-runtime", region_name=aws_region)
             json_data = {
                 "anthropic_version": "bedrock-2023-05-31",

--- a/src/main.py
+++ b/src/main.py
@@ -98,6 +98,14 @@ def parse_args() -> argparse.Namespace:
     )
 
     improve_parser.add_argument(
+        "-ap",
+        "--aws-profile",
+        type=str,
+        default=None,
+        help="AWS profile name to use for Bedrock API mode. If not specified, uses default AWS credential chain.",
+    )
+
+    improve_parser.add_argument(
         "-ui",
         "--user-input-description",
         type=str,
@@ -240,6 +248,8 @@ def main() -> None:
             args.eval_model,
             initial_prompt,
             args.user_input_description,
+            aws_region=args.aws_region,
+            aws_profile=args.aws_profile,
         )
         initial_avg_score = average_satisfaction(initial_evaluation)
         print("\033[35m" + "\n🧪 Initial Evaluation Result:" + "\033[0m")
@@ -262,6 +272,7 @@ def main() -> None:
                     current_prompt,
                     args.user_input_description,
                     aws_region=args.aws_region,
+                    aws_profile=args.aws_profile,
                 )
                 print("\033[35m" + "🔍 Evaluation Result:" + "\033[0m")
                 print(json.dumps(evaluation_result, indent=2, ensure_ascii=False))
@@ -290,6 +301,7 @@ def main() -> None:
                 args.user_input_description,
                 apply_techniques=apply_techniques,
                 aws_region=args.aws_region,
+                aws_profile=args.aws_profile,
             )
             print("\033[32m" + "\n✅ Improved Prompt:" + "\033[0m")
             print(show_prompt(current_prompt))
@@ -300,6 +312,8 @@ def main() -> None:
                 args.eval_model,
                 current_prompt,
                 args.user_input_description,
+                aws_region=args.aws_region,
+                aws_profile=args.aws_profile,
             )
             final_avg_score = average_satisfaction(evaluation_result)
             print("\033[35m" + "\n🎯 Final Evaluation Result:" + "\033[0m")
@@ -338,6 +352,8 @@ def main() -> None:
                 apply_techniques,
                 args.test_separator,
                 tools,
+                args.aws_region,
+                args.aws_profile,
             )
 
         if args.report_dir:

--- a/src/webui.py
+++ b/src/webui.py
@@ -24,6 +24,7 @@ def run_evaluation(
     separator,
     tools_json,
     aws_region,
+    aws_profile,
 ):
     report_dir = Path(tempfile.mkdtemp())
     report_dir.mkdir(parents=True, exist_ok=True)
@@ -81,6 +82,8 @@ def run_evaluation(
             cmd += ["--tools-path", str(tools_path)]
         if aws_region:
             cmd += ["--aws-region", aws_region]
+        if aws_profile:
+            cmd += ["--aws-profile", aws_profile]
 
         try:
             subprocess.run(cmd, text=True, check=True)
@@ -161,6 +164,10 @@ with gr.Blocks() as demo:
                 value="us-east-1",
                 placeholder="e.g., us-east-1",
             )
+            aws_profile = gr.Textbox(
+                label="AWS Profile (optional, for bedrock api mode)",
+                placeholder="e.g., default, my-profile",
+            )
             description = gr.Textbox(label="User Input Description")
             iterations = gr.Slider(1, 10, value=3, step=1, label="Max Iterations")
             threshold = gr.Slider(
@@ -201,6 +208,7 @@ with gr.Blocks() as demo:
             separator,
             tools_json,
             aws_region,
+            aws_profile,
         ],
         outputs=[result, download_html, download_json],
     )


### PR DESCRIPTION
Introduces the --aws-profile option to CLI, web UI, and all relevant function calls to allow specifying an AWS profile for Bedrock API requests. Updates documentation and propagates aws_profile through the codebase for improved credential management.

Following best security practices we use AWS Profiles. 