### PR TITLE
Disable run injection test by default in the WebUI

### DIFF
--- a/src/webui.py
+++ b/src/webui.py
@@ -370,7 +370,7 @@ with gr.Blocks() as demo:
                         ],
                         label="Defense Techniques",
                     )
-                    test = gr.Checkbox(label="Run Injection Test", value=True)
+                    test = gr.Checkbox(label="Run Injection Test", value=False)
                     separator = gr.Textbox(label="Attack Separator", value="")
                     tools_json = gr.Textbox(label="Tools (JSON)", lines=4)
                 with gr.Column():


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the `run_evaluation` function in `src/webui.py`. The default value for the "Run Injection Test" checkbox has been changed to unchecked.

* Changed the default value of the `test` checkbox ("Run Injection Test") from `True` to `False` in the `run_evaluation` function (`src/webui.py`).