### PR TITLE
Fix dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          pip install -e ".[dev]"
       - name: Run tests
         run: |
           pytest --maxfail=1 --disable-warnings -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,19 +7,23 @@ name = "prompt-hardener"
 version = "0.5.0"
 description = "Analyze prompt-injection risk in LLM-based agents and applications."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = { text = "Apache 2.0" }
 dependencies = [
   "requests==2.32.5",
   "openai==2.21.0",
   "argparse==1.4.0",
-  "ruff==0.15.1",
   "gradio==6.8.0",
   "anthropic==0.83.0",
   "boto3==1.42.50",
-  "pytest==9.0.2",
   "pyyaml==6.0.3",
   "jsonschema==4.26.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest==9.0.2",
+  "ruff==0.15.1",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,11 @@ requires-python = ">=3.10"
 license = { text = "Apache 2.0" }
 dependencies = [
   "requests==2.32.5",
-  "openai==2.21.0",
+  "openai==2.23.0",
   "argparse==1.4.0",
   "gradio==6.8.0",
   "anthropic==0.83.0",
-  "boto3==1.42.50",
+  "boto3==1.42.55",
   "pyyaml==6.0.3",
   "jsonschema==4.26.0",
 ]
@@ -23,7 +23,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest==9.0.2",
-  "ruff==0.15.1",
+  "ruff==0.15.2",
 ]
 
 [project.scripts]


### PR DESCRIPTION
This pull request updates dependencies and refines Python version requirements for the `prompt-hardener` project. It also reorganizes development dependencies into an optional group for improved clarity and maintainability.

Dependency updates:

* Updated `openai` to version 2.23.0 and `boto3` to version 1.42.55 for improved compatibility and bug fixes.
* Raised minimum required Python version from 3.8 to 3.10, aligning with modern Python standards.

Development environment improvements:

* Moved `pytest` and `ruff` to a new `[project.optional-dependencies]` group named `dev`, and updated `ruff` to version 0.15.2, making development dependencies optional and easier to manage.