### PR TITLE
Refactor release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,73 +1,68 @@
 name: Release
 
 on:
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version tag (e.g. v0.4.0)"
+        description: "Existing release version tag to publish (e.g. v0.5.0)"
         required: true
-        type: string
-      target_ref:
-        description: "Git ref to release from (branch/sha). Default: main"
-        required: false
-        default: "main"
         type: string
 
 concurrency:
-  group: release-${{ github.repository }}
+  group: release-${{ github.repository }}-${{ github.ref_name }}
   cancel-in-progress: false
 
 permissions:
-  contents: write          # create/push tags, create GitHub Release
+  contents: write          # create/update GitHub Release
 
 jobs:
   release:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Validate version format
+      - name: Resolve release tag
+        id: release_tag
         shell: bash
         run: |
           set -euo pipefail
-          v="${{ inputs.version }}"
+
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            v="${GITHUB_REF_NAME}"
+          else
+            v="${{ inputs.version }}"
+          fi
+
           if [[ ! "$v" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([\-+].*)?$ ]]; then
             echo "Invalid version: $v"
             echo "Expected semver like v0.4.0 (optionally with -rc.1, +meta)"
             exit 1
           fi
+          echo "tag=$v" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout target ref
+      - name: Checkout release tag
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.target_ref }}
+          ref: refs/tags/${{ steps.release_tag.outputs.tag }}
           fetch-depth: 0
 
-      - name: Fail if tag already exists
+      - name: Verify tag exists
         shell: bash
         run: |
           set -euo pipefail
-          tag="${{ inputs.version }}"
-          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
-            echo "Tag already exists locally: ${tag}"
-            exit 1
-          fi
-          # remote check
-          if git ls-remote --tags origin "refs/tags/${tag}" | grep -q .; then
-            echo "Tag already exists on origin: ${tag}"
+          tag="${{ steps.release_tag.outputs.tag }}"
+
+          if ! git rev-parse -q --verify "refs/tags/${tag}" >/dev/null; then
+            echo "Tag does not exist locally after checkout: ${tag}"
             exit 1
           fi
 
-      - name: Create & push git tag
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag="${{ inputs.version }}"
-          sha="$(git rev-parse HEAD)"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-          git tag -a "$tag" -m "Release $tag" "$sha"
-          git push origin "refs/tags/$tag"
+          if ! git ls-remote --tags origin "refs/tags/${tag}" | grep -q .; then
+            echo "Tag does not exist on origin: ${tag}"
+            exit 1
+          fi
 
       - name: Build Python package (wheel)
         shell: bash
@@ -80,8 +75,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
-          prerelease: ${{ contains(inputs.version, '-rc.') || contains(inputs.version, '-beta') || contains(inputs.version, '-alpha') }}
-          tag_name: ${{ inputs.version }}
+          prerelease: ${{ contains(steps.release_tag.outputs.tag, '-rc.') || contains(steps.release_tag.outputs.tag, '-beta') || contains(steps.release_tag.outputs.tag, '-alpha') }}
+          tag_name: ${{ steps.release_tag.outputs.tag }}
           generate_release_notes: true
           draft: false
           files: |


### PR DESCRIPTION
This pull request updates the release workflow to improve reliability and clarity around tag-based releases. The workflow now triggers on tag pushes, ensures the tag exists both locally and on the remote before proceeding, and removes unnecessary steps related to tag creation. The concurrency group is also refined to prevent overlapping releases for different tags.

**Workflow triggers and tag handling:**

* The workflow now triggers automatically on pushes to tags matching the pattern `v*`, supporting tag-based releases.
* The release process verifies that the specified tag exists both locally and on the remote before proceeding, preventing accidental releases from missing or incorrect tags.
* The step to create and push a git tag has been removed; the workflow now assumes the tag already exists, simplifying the release process.

**Input and concurrency improvements:**

* The `version` input description is clarified to indicate it should be an existing release tag, and the `target_ref` input is removed to reduce confusion.
* The concurrency group is updated to include the tag name, preventing overlapping releases for different tags within the same repository.

**Release step updates:**

* The `Create GitHub Release` step now uses the resolved tag from earlier steps for both the prerelease check and tag name, ensuring consistency.