### PR TITLE
Bump version to 0.6.0 and add version check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Choose the installation method that fits how you want to use Prompt Hardener.
 Recommended when you want to install Prompt Hardener as an isolated CLI tool.
 
 ```bash
-pipx install https://github.com/cybozu/prompt-hardener/releases/download/v0.5.0/prompt_hardener-0.5.0-py3-none-any.whl
+pipx install https://github.com/cybozu/prompt-hardener/releases/download/v0.6.0/prompt_hardener-0.6.0-py3-none-any.whl
 ```
 
 ### Using [uv](https://docs.astral.sh/uv/)
@@ -39,7 +39,7 @@ pipx install https://github.com/cybozu/prompt-hardener/releases/download/v0.5.0/
 Recommended if you already use `uv` for Python tooling.
 
 ```bash
-uv tool install https://github.com/cybozu/prompt-hardener/releases/download/v0.5.0/prompt_hardener-0.5.0-py3-none-any.whl
+uv tool install https://github.com/cybozu/prompt-hardener/releases/download/v0.6.0/prompt_hardener-0.6.0-py3-none-any.whl
 ```
 
 ### Using pip
@@ -47,7 +47,7 @@ uv tool install https://github.com/cybozu/prompt-hardener/releases/download/v0.5
 Use this if you prefer a standard Python environment.
 
 ```bash
-pip install https://github.com/cybozu/prompt-hardener/releases/download/v0.5.0/prompt_hardener-0.5.0-py3-none-any.whl
+pip install https://github.com/cybozu/prompt-hardener/releases/download/v0.6.0/prompt_hardener-0.6.0-py3-none-any.whl
 
 # Or install the latest code from main
 pip install git+https://github.com/cybozu/prompt-hardener.git
@@ -77,7 +77,7 @@ The fastest way to try Prompt Hardener is to use one of the included example spe
 
 ```bash
 # Install with uv
-uv tool install https://github.com/cybozu/prompt-hardener/releases/download/v0.5.0/prompt_hardener-0.5.0-py3-none-any.whl
+uv tool install https://github.com/cybozu/prompt-hardener/releases/download/v0.6.0/prompt_hardener-0.6.0-py3-none-any.whl
 ```
 
 If you prefer `pipx`, `pip`, or a development install, see [Installation](#installation).

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -81,7 +81,7 @@ Output:
 
 **Agent:** Comment Summarizer (type: chatbot)
 **Generated:** 2025-01-15T10:30:00Z
-**Tool Version:** 0.5.0 | **Rules Version:** 1.0 | **Rules Evaluated:** 3
+**Tool Version:** 0.6.0 | **Rules Version:** 1.0 | **Rules Evaluated:** 3
 
 ## Summary
 
@@ -267,7 +267,7 @@ Output:
 
 **Agent:** Customer Support Agent (type: agent)
 **Generated:** 2025-01-15T11:00:00Z
-**Tool Version:** 0.5.0 | **Rules Version:** 1.0 | **Rules Evaluated:** 8
+**Tool Version:** 0.6.0 | **Rules Version:** 1.0 | **Rules Evaluated:** 8
 
 ## Summary
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prompt-hardener"
-version = "0.5.0"
 description = "Analyze prompt-injection risk in LLM-based agents and applications."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache 2.0" }
+dynamic = ["version"]
 dependencies = [
   "requests==2.32.5",
   "openai==2.23.0",
@@ -37,6 +37,9 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 prompt_hardener = ["schemas/*.json", "templates/*.yaml", "catalog/*.yaml"]
+
+[tool.setuptools.dynamic]
+version = {attr = "prompt_hardener.__version__"}
 
 [tool.uv]
 exclude-newer = "1 week"

--- a/src/prompt_hardener/__init__.py
+++ b/src/prompt_hardener/__init__.py
@@ -1,0 +1,8 @@
+"""Prompt Hardener package metadata."""
+
+__version__ = "0.6.0"
+PRODUCT_NAME = "Prompt Hardener"
+
+
+def get_version_display() -> str:
+    return f"{__version__} ({PRODUCT_NAME})"

--- a/src/prompt_hardener/analyze/engine.py
+++ b/src/prompt_hardener/analyze/engine.py
@@ -3,6 +3,7 @@
 import hashlib
 from datetime import datetime, timezone
 
+from prompt_hardener import __version__ as TOOL_VERSION
 from prompt_hardener.agent_spec import load_and_validate
 from prompt_hardener.analyze.attack_paths import enumerate_attack_paths
 from prompt_hardener.analyze.report import (
@@ -15,7 +16,6 @@ from prompt_hardener.analyze.rules import _ensure_rules_loaded, get_rules
 from prompt_hardener.analyze.scoring import compute_scores
 from prompt_hardener.models import AgentSpec
 
-TOOL_VERSION = "0.5.0"
 RULES_VERSION = "1.0"
 
 

--- a/src/prompt_hardener/main.py
+++ b/src/prompt_hardener/main.py
@@ -7,6 +7,7 @@ from prompt_hardener.gen_report import (
     generate_improvement_report,
     generate_evaluation_report,
 )
+from prompt_hardener import get_version_display
 from prompt_hardener.prompt import (
     parse_prompt_input,
     write_prompt_output,
@@ -16,12 +17,19 @@ from prompt_hardener.prompt_improvement import run_improvement_loop
 from prompt_hardener.webui import launch_webui
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv=None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Analyze prompt-injection risk in agent specs with static rules, optional LLM-backed remediation, and attack simulation."
     )
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=get_version_display(),
+    )
     subparsers = parser.add_subparsers(dest="command", required=True)
 
+    subparsers.add_parser("version", help="Show the prompt-hardener version")
     subparsers.add_parser("webui", help="Launch the web UI")
 
     # --- init subcommand ---
@@ -558,7 +566,7 @@ def parse_args() -> argparse.Namespace:
         help="Directory to write a full HTML and JSON report after execution.",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     # Validation: Ensure --input-format and --attack-api-mode are the same
     if (
@@ -901,8 +909,8 @@ def _prompt_input_to_agent_spec(prompt_input, args):
     )
 
 
-def main() -> None:
-    args = parse_args()
+def main(argv=None) -> None:
+    args = parse_args(argv)
     if args.command == "init":
         run_init(args)
     elif args.command == "validate":
@@ -917,6 +925,8 @@ def main() -> None:
         run_report_cmd(args)
     elif args.command == "diff":
         run_diff_cmd(args)
+    elif args.command == "version":
+        print(get_version_display())
     elif args.command == "webui":
         print("\033[36m" + "Launching web UI..." + "\033[0m")
         launch_webui()

--- a/src/prompt_hardener/remediate/engine.py
+++ b/src/prompt_hardener/remediate/engine.py
@@ -13,6 +13,7 @@ from prompt_hardener.remediate.prompt_layer import remediate_prompt
 from prompt_hardener.remediate.report import RemediationReport
 from prompt_hardener.remediate.tool_layer import remediate_tool
 
+
 def _compute_safe_spec_patches(spec):
     """Compute deterministic, safe patches for the agent spec.
 

--- a/src/prompt_hardener/remediate/engine.py
+++ b/src/prompt_hardener/remediate/engine.py
@@ -4,6 +4,7 @@ import hashlib
 from datetime import datetime, timezone
 from typing import Callable, List, Optional
 
+from prompt_hardener import __version__ as TOOL_VERSION
 from prompt_hardener.agent_spec import load_and_validate, write_updated_spec
 from prompt_hardener.analyze.engine import run_analyze
 from prompt_hardener.analyze.scoring import TYPE_LAYERS
@@ -11,9 +12,6 @@ from prompt_hardener.remediate.arch_layer import remediate_architecture
 from prompt_hardener.remediate.prompt_layer import remediate_prompt
 from prompt_hardener.remediate.report import RemediationReport
 from prompt_hardener.remediate.tool_layer import remediate_tool
-
-TOOL_VERSION = "0.5.0"
-
 
 def _compute_safe_spec_patches(spec):
     """Compute deterministic, safe patches for the agent spec.

--- a/src/prompt_hardener/simulate/models.py
+++ b/src/prompt_hardener/simulate/models.py
@@ -3,8 +3,6 @@
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
-from prompt_hardener import __version__ as TOOL_VERSION
-
 
 @dataclass
 class ScenarioResult:

--- a/src/prompt_hardener/simulate/models.py
+++ b/src/prompt_hardener/simulate/models.py
@@ -3,6 +3,10 @@
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
+from prompt_hardener import __version__
+
+TOOL_VERSION = __version__
+
 
 @dataclass
 class ScenarioResult:

--- a/src/prompt_hardener/simulate/models.py
+++ b/src/prompt_hardener/simulate/models.py
@@ -3,8 +3,7 @@
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
-
-TOOL_VERSION = "0.5.0"
+from prompt_hardener import __version__ as TOOL_VERSION
 
 
 @dataclass

--- a/tests/fixtures/analyze_result.json
+++ b/tests/fixtures/analyze_result.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "tool_version": "0.5.0",
+    "tool_version": "0.6.0",
     "timestamp": "2025-01-15T10:30:00Z",
     "agent_name": "Customer Support Agent",
     "agent_type": "agent",

--- a/tests/fixtures/remediate_result.json
+++ b/tests/fixtures/remediate_result.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "tool_version": "0.5.0",
+    "tool_version": "0.6.0",
     "timestamp": "2025-01-15T11:30:00Z",
     "agent_type": "agent",
     "layers": ["prompt", "tool", "architecture"],

--- a/tests/fixtures/simulate_result.json
+++ b/tests/fixtures/simulate_result.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "tool_version": "0.5.0",
+    "tool_version": "0.6.0",
     "timestamp": "2025-01-15T11:00:00Z",
     "agent_type": "agent",
     "models": {

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import jsonschema
 
+from prompt_hardener import __version__ as PACKAGE_VERSION
 from prompt_hardener.agent_spec import dict_to_agent_spec, load_yaml
 from prompt_hardener.analyze.attack_paths.graph import build_attack_graph
 from prompt_hardener.analyze.attack_paths.normalize import normalize_spec
@@ -1086,7 +1087,7 @@ class TestReportSerialization:
     def _make_report(self):
         return AnalyzeReport(
             metadata=AnalyzeMetadata(
-                tool_version="0.5.0",
+                tool_version=PACKAGE_VERSION,
                 timestamp="2026-03-08T12:00:00Z",
                 agent_name="Test Agent",
                 agent_type="rag",
@@ -1160,7 +1161,7 @@ class TestReportSerialization:
     def test_to_dict_roundtrip(self):
         report = self._make_report()
         d = report.to_dict()
-        assert d["metadata"]["tool_version"] == "0.5.0"
+        assert d["metadata"]["tool_version"] == PACKAGE_VERSION
         assert d["summary"]["risk_level"] == "high"
         assert len(d["findings"]) == 1
         assert d["findings"][0]["id"] == "finding-001"

--- a/tests/test_high_priority_fixes.py
+++ b/tests/test_high_priority_fixes.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 
+from prompt_hardener import __version__ as PACKAGE_VERSION
 from prompt_hardener.analyze.report import Finding
 from prompt_hardener.analyze.scoring import compute_scores
 from prompt_hardener.analyze.engine import run_analyze
@@ -111,7 +112,7 @@ class TestH2RemediationMetadataLayers:
 
         mock_analyze_report = AnalyzeReport(
             metadata=AnalyzeMetadata(
-                tool_version="0.5.0",
+                tool_version=PACKAGE_VERSION,
                 timestamp="2026-01-01T00:00:00Z",
                 agent_name="Test",
                 agent_type="agent",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,37 @@
+import pytest
+
+from prompt_hardener import get_version_display
+from prompt_hardener.main import main, parse_args
+
+
+def test_parse_args_version_subcommand():
+    args = parse_args(["version"])
+    assert args.command == "version"
+
+
+def test_main_short_version_flag(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        main(["-v"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out == get_version_display() + "\n"
+    assert captured.err == ""
+
+
+def test_main_long_version_flag(capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        main(["--version"])
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out == get_version_display() + "\n"
+    assert captured.err == ""
+
+
+def test_main_version_subcommand(capsys):
+    main(["version"])
+
+    captured = capsys.readouterr()
+    assert captured.out == get_version_display() + "\n"
+    assert captured.err == ""

--- a/tests/test_remediate.py
+++ b/tests/test_remediate.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import jsonschema
 import pytest
 
+from prompt_hardener import __version__ as PACKAGE_VERSION
 from prompt_hardener.analyze.report import Finding
 from prompt_hardener.llm.client import LLMClient
 from prompt_hardener.llm.types import LLMResponse
@@ -169,7 +170,7 @@ class TestRemediationReport:
     def test_empty_report(self):
         report = RemediationReport(
             metadata={
-                "tool_version": "0.5.0",
+                "tool_version": PACKAGE_VERSION,
                 "timestamp": "2025-01-01T00:00:00+00:00",
                 "agent_type": "chatbot",
             }
@@ -183,7 +184,7 @@ class TestRemediationReport:
     def test_report_with_prompt_only(self):
         report = RemediationReport(
             metadata={
-                "tool_version": "0.5.0",
+                "tool_version": PACKAGE_VERSION,
                 "timestamp": "t",
                 "agent_type": "chatbot",
             },
@@ -204,7 +205,11 @@ class TestRemediationReport:
 
     def test_report_with_all_layers(self):
         report = RemediationReport(
-            metadata={"tool_version": "0.5.0", "timestamp": "t", "agent_type": "agent"},
+            metadata={
+                "tool_version": PACKAGE_VERSION,
+                "timestamp": "t",
+                "agent_type": "agent",
+            },
             prompt=PromptRemediation(
                 changes="improved",
                 original_system_prompt="Before",
@@ -226,7 +231,11 @@ class TestRemediationReport:
 
     def test_summary_risk_level_from_recommendations(self):
         report = RemediationReport(
-            metadata={"tool_version": "0.5.0", "timestamp": "t", "agent_type": "agent"},
+            metadata={
+                "tool_version": PACKAGE_VERSION,
+                "timestamp": "t",
+                "agent_type": "agent",
+            },
             tool=[Recommendation(severity="critical", title="T", description="D")],
         )
         d = report.to_dict()
@@ -235,7 +244,7 @@ class TestRemediationReport:
     def test_summary_risk_level_low_when_no_recommendations(self):
         report = RemediationReport(
             metadata={
-                "tool_version": "0.5.0",
+                "tool_version": PACKAGE_VERSION,
                 "timestamp": "t",
                 "agent_type": "chatbot",
             },
@@ -1358,7 +1367,7 @@ class TestEngine:
             layers=["tool"],
         )
 
-        assert report.metadata["tool_version"] == "0.5.0"
+        assert report.metadata["tool_version"] == PACKAGE_VERSION
         assert "timestamp" in report.metadata
         assert report.metadata["agent_type"] == "agent"
         assert "agent_spec_digest" in report.metadata
@@ -1545,7 +1554,7 @@ class TestSchemaDriftGuard:
     def _build_sample_report():
         return RemediationReport(
             metadata={
-                "tool_version": "0.5.0",
+                "tool_version": PACKAGE_VERSION,
                 "timestamp": "2025-01-01T00:00:00+00:00",
                 "agent_type": "agent",
             },

--- a/uv.lock
+++ b/uv.lock
@@ -1375,7 +1375,7 @@ wheels = [
 
 [[package]]
 name = "prompt-hardener"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
This pull request updates the versioning system of the Prompt Hardener project from hardcoded version strings to a dynamic, centralized approach. It introduces a new `__version__` attribute in the package, ensures all components and reports reference this version, and adds a user-friendly CLI version command. The documentation, test fixtures, and tests are also updated to reflect the new versioning scheme.

**Versioning and Metadata Improvements**
- Introduced a central `__version__ = "0.6.0"` and `PRODUCT_NAME` in `src/prompt_hardener/__init__.py`, along with a `get_version_display()` helper. All internal references to the tool version now import this value instead of using hardcoded strings. [[1]](diffhunk://#diff-a8efeda87860020d3faf6edadb87a5edd10f6225052c78aef7f3bd3f05e3d709R1-R8) [[2]](diffhunk://#diff-bf1a3ad6f2ff47796065485d6013cbe649172ce7c876a380337e1622a407f0f5R6) [[3]](diffhunk://#diff-bf1a3ad6f2ff47796065485d6013cbe649172ce7c876a380337e1622a407f0f5L18) [[4]](diffhunk://#diff-13a6971d1af507423796d0a7f4c094e76480f57734148119f8ad5d773be35ca6R7) [[5]](diffhunk://#diff-13a6971d1af507423796d0a7f4c094e76480f57734148119f8ad5d773be35ca6L15-L17) [[6]](diffhunk://#diff-4d003cbfa82c014ee80f3694f500f9c698579de44aa80bea29452178745b77abL6-R6)
- Updated `pyproject.toml` to use dynamic versioning, pulling the version from the package attribute instead of a static value. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R11) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R41-R43)

**CLI Enhancements**
- Added a `version` subcommand and `-v/--version` flags to the CLI, displaying the tool version using the new dynamic system. Updated the argument parsing to support these features and improved test coverage for them. [[1]](diffhunk://#diff-5dc21e8975392e666f71e5729d171fe95d0cb86f2e27f79be9ea8bc83fd5394eR10) [[2]](diffhunk://#diff-5dc21e8975392e666f71e5729d171fe95d0cb86f2e27f79be9ea8bc83fd5394eL19-R32) [[3]](diffhunk://#diff-5dc21e8975392e666f71e5729d171fe95d0cb86f2e27f79be9ea8bc83fd5394eL561-R569) [[4]](diffhunk://#diff-5dc21e8975392e666f71e5729d171fe95d0cb86f2e27f79be9ea8bc83fd5394eL904-R913) [[5]](diffhunk://#diff-5dc21e8975392e666f71e5729d171fe95d0cb86f2e27f79be9ea8bc83fd5394eR928-R929) [[6]](diffhunk://#diff-41d180f6f7233d175c2dfe36c45c4ea80eed4754fa7ed4eed46ccde1b2a778c7R1-R37)

**Documentation and Example Updates**
- Updated all installation instructions and tutorial outputs in `README.md` and `docs/tutorials.md` to reference version `0.6.0` instead of `0.5.0`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R50) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L80-R80) [[3]](diffhunk://#diff-b7a7762b6c810293656a39cd828555954a0ce1c21f75c1bde2390fc8b2d6272aL84-R84) [[4]](diffhunk://#diff-b7a7762b6c810293656a39cd828555954a0ce1c21f75c1bde2390fc8b2d6272aL270-R270)

**Test and Fixture Synchronization**
- Updated test fixtures and test assertions to expect the dynamic version value, ensuring consistency across the codebase. [[1]](diffhunk://#diff-ebc90a5e9a20b671e621205422d956fd81d05236fc1a4b05c615d3f38489311dL3-R3) [[2]](diffhunk://#diff-cc81cacd27da9cb8e2fc44d8153a06df063733aacca8777e78315e671e61d46fL3-R3) [[3]](diffhunk://#diff-5e860fe52c8f5dffa3209e2955b93a1dc6ef1d125b4b358ae5320e2f9118e8cfL3-R3) [[4]](diffhunk://#diff-d6fbc7eaec62138fe0585d15d5dc3477a4bb17cae47bba508e309513620f5be8R11) [[5]](diffhunk://#diff-d6fbc7eaec62138fe0585d15d5dc3477a4bb17cae47bba508e309513620f5be8L1089-R1090) [[6]](diffhunk://#diff-d6fbc7eaec62138fe0585d15d5dc3477a4bb17cae47bba508e309513620f5be8L1163-R1164) [[7]](diffhunk://#diff-98105a175a6021bd9a2d1f1a230fbbfb880a55436378eb3757077e8fd55b0aaeR8) [[8]](diffhunk://#diff-98105a175a6021bd9a2d1f1a230fbbfb880a55436378eb3757077e8fd55b0aaeL114-R115) [[9]](diffhunk://#diff-59a1506186c32c49c8bfcfbb47afe26a0d0848a5c07fec60dc8a6b06e02d3302R13) [[10]](diffhunk://#diff-59a1506186c32c49c8bfcfbb47afe26a0d0848a5c07fec60dc8a6b06e02d3302L172-R173) [[11]](diffhunk://#diff-59a1506186c32c49c8bfcfbb47afe26a0d0848a5c07fec60dc8a6b06e02d3302L186-R187) [[12]](diffhunk://#diff-59a1506186c32c49c8bfcfbb47afe26a0d0848a5c07fec60dc8a6b06e02d3302L207-R212) [[13]](diffhunk://#diff-59a1506186c32c49c8bfcfbb47afe26a0d0848a5c07fec60dc8a6b06e02d3302L229-R238) [[14]](diffhunk://#diff-59a1506186c32c49c8bfcfbb47afe26a0d0848a5c07fec60dc8a6b06e02d3302L238-R247) [[15]](diffhunk://#diff-59a1506186c32c49c8bfcfbb47afe26a0d0848a5c07fec60dc8a6b06e02d3302L1361-R1370) [[16]](diffhunk://#diff-59a1506186c32c49c8bfcfbb47afe26a0d0848a5c07fec60dc8a6b06e02d3302L1548-R1557)

These changes make the versioning process more robust, reduce manual update errors, and improve the user and developer experience.